### PR TITLE
Fix nil test execution start time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/annexhq/annex
 go 1.22.0
 
 require (
-	github.com/annexhq/annex-proto v0.0.0-20240530212352-3ca8e8531454
+	github.com/annexhq/annex-proto v0.0.0-20240603062920-3b6f92e0f992
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cristalhq/aconfig v0.18.5
 	github.com/cristalhq/aconfig/aconfigyaml v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/annexhq/annex-proto v0.0.0-20240530212352-3ca8e8531454 h1:6P9Y+tu4YY7M2xQqNXtPewDxFD9T1daJKW2eNrY7S78=
-github.com/annexhq/annex-proto v0.0.0-20240530212352-3ca8e8531454/go.mod h1:DSGBmFfVcqUeh9rVjHeZq9bFyZkSQ5MPdTFZ8X58X9E=
+github.com/annexhq/annex-proto v0.0.0-20240603062920-3b6f92e0f992 h1:xJ7liPSDhy4e7vCoG+4+ckWgRfij/I+w3MFNtzVYIUY=
+github.com/annexhq/annex-proto v0.0.0-20240603062920-3b6f92e0f992/go.mod h1:DSGBmFfVcqUeh9rVjHeZq9bFyZkSQ5MPdTFZ8X58X9E=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.20.0 h1:631+KvYbsBZxmuJjYwhezVsrfc/TbqtZV4QcxOX1fOI=
 github.com/apache/thrift v0.20.0/go.mod h1:hOk1BQqcp2OLzGsyVXdfMk7YFlMxK3aoEVhjD06QhB8=

--- a/internal/fake/workflow_history.go
+++ b/internal/fake/workflow_history.go
@@ -3,7 +3,6 @@ package fake
 import (
 	"time"
 
-	testv1 "github.com/annexhq/annex-proto/gen/go/type/test/v1"
 	"github.com/google/uuid"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
@@ -113,26 +112,6 @@ func GenCaseFailureHistory(
 			},
 			{
 				EventId:   3,
-				EventTime: parseTime("2024-05-28T10:04:10.569149Z"),
-				EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED,
-				TaskId:    1048612,
-				Attributes: &history.HistoryEvent_WorkflowExecutionSignaledEventAttributes{
-					WorkflowExecutionSignaledEventAttributes: &history.WorkflowExecutionSignaledEventAttributes{
-						SignalName: testv1.TestSignal_TEST_SIGNAL_START_TEST.String(),
-						Input: &common.Payloads{
-							Payloads: []*common.Payload{
-								{
-									Metadata: map[string][]byte{"encoding": []byte("YmluYXJ5L251bGw=")},
-								},
-							},
-						},
-						Identity: "hidden",
-						Header:   &common.Header{},
-					},
-				},
-			},
-			{
-				EventId:   4,
 				EventTime: parseTime("2024-05-28T10:04:10.579381Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_STARTED,
 				TaskId:    1048614,
@@ -146,14 +125,14 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   5,
+				EventId:   4,
 				EventTime: parseTime("2024-05-28T10:04:10.596592Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
 				TaskId:    1048618,
 				Attributes: &history.HistoryEvent_WorkflowTaskCompletedEventAttributes{
 					WorkflowTaskCompletedEventAttributes: &history.WorkflowTaskCompletedEventAttributes{
 						ScheduledEventId: 2,
-						StartedEventId:   4,
+						StartedEventId:   3,
 						Identity:         "hidden",
 						WorkerVersion: &common.WorkerVersionStamp{
 							BuildId: "81194cb0e5cc14ffb23da13a22ce4152",
@@ -164,20 +143,7 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   6,
-				EventTime: parseTime("2024-05-28T10:04:10.596617Z"),
-				EventType: enums.EVENT_TYPE_TIMER_STARTED,
-				TaskId:    1048619,
-				Attributes: &history.HistoryEvent_TimerStartedEventAttributes{
-					TimerStartedEventAttributes: &history.TimerStartedEventAttributes{
-						TimerId:                      "6",
-						StartToFireTimeout:           durationpb.New(30 * time.Second),
-						WorkflowTaskCompletedEventId: 5,
-					},
-				},
-			},
-			{
-				EventId:   7,
+				EventId:   5,
 				EventTime: parseTime("2024-05-28T10:04:10.596623Z"),
 				EventType: enums.EVENT_TYPE_MARKER_RECORDED,
 				TaskId:    1048620,
@@ -199,12 +165,12 @@ func GenCaseFailureHistory(
 								},
 							},
 						},
-						WorkflowTaskCompletedEventId: 5,
+						WorkflowTaskCompletedEventId: 4,
 					},
 				},
 			},
 			{
-				EventId:   8,
+				EventId:   6,
 				EventTime: parseTime("2024-05-28T10:04:10.596632Z"),
 				EventType: enums.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED,
 				TaskId:    1048621,
@@ -223,7 +189,7 @@ func GenCaseFailureHistory(
 						ScheduleToStartTimeout:       durationpb.New(60 * time.Second),
 						StartToCloseTimeout:          durationpb.New(60 * time.Second),
 						HeartbeatTimeout:             durationpb.New(0),
-						WorkflowTaskCompletedEventId: 5,
+						WorkflowTaskCompletedEventId: 4,
 						RetryPolicy: &common.RetryPolicy{
 							InitialInterval:    durationpb.New(time.Second),
 							BackoffCoefficient: 2,
@@ -235,13 +201,13 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   9,
+				EventId:   7,
 				EventTime: parseTime("2024-05-28T10:04:10.603343Z"),
 				EventType: enums.EVENT_TYPE_ACTIVITY_TASK_STARTED,
 				TaskId:    1048629,
 				Attributes: &history.HistoryEvent_ActivityTaskStartedEventAttributes{
 					ActivityTaskStartedEventAttributes: &history.ActivityTaskStartedEventAttributes{
-						ScheduledEventId: 8,
+						ScheduledEventId: 6,
 						Identity:         "hidden",
 						RequestId:        "a7f20551-57c4-49e5-92f5-9f11c87a836b",
 						Attempt:          1,
@@ -249,7 +215,7 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   10,
+				EventId:   8,
 				EventTime: parseTime("2024-05-28T10:04:11.649503Z"),
 				EventType: enums.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
 				TaskId:    1048630,
@@ -263,14 +229,14 @@ func GenCaseFailureHistory(
 								},
 							},
 						},
-						ScheduledEventId: 8,
-						StartedEventId:   9,
+						ScheduledEventId: 6,
+						StartedEventId:   7,
 						Identity:         "hidden",
 					},
 				},
 			},
 			{
-				EventId:   11,
+				EventId:   9,
 				EventTime: parseTime("2024-05-28T10:04:11.649515Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
 				TaskId:    1048631,
@@ -287,13 +253,13 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   12,
+				EventId:   10,
 				EventTime: parseTime("2024-05-28T10:04:11.662908Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_STARTED,
 				TaskId:    1048635,
 				Attributes: &history.HistoryEvent_WorkflowTaskStartedEventAttributes{
 					WorkflowTaskStartedEventAttributes: &history.WorkflowTaskStartedEventAttributes{
-						ScheduledEventId: 11,
+						ScheduledEventId: 9,
 						Identity:         "hidden",
 						RequestId:        "1b374228-7af8-451e-9797-b59b8af00313",
 						HistorySizeBytes: 1466,
@@ -301,14 +267,14 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   13,
+				EventId:   11,
 				EventTime: parseTime("2024-05-28T10:04:11.666495Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
 				TaskId:    1048639,
 				Attributes: &history.HistoryEvent_WorkflowTaskCompletedEventAttributes{
 					WorkflowTaskCompletedEventAttributes: &history.WorkflowTaskCompletedEventAttributes{
-						ScheduledEventId: 11,
-						StartedEventId:   12,
+						ScheduledEventId: 9,
+						StartedEventId:   10,
 						Identity:         "hidden",
 						WorkerVersion: &common.WorkerVersionStamp{
 							BuildId: "81194cb0e5cc14ffb23da13a22ce4152",
@@ -338,7 +304,7 @@ func GenCaseFailureHistory(
 						ScheduleToStartTimeout:       durationpb.New(60 * time.Second),
 						StartToCloseTimeout:          durationpb.New(60 * time.Second),
 						HeartbeatTimeout:             durationpb.New(0),
-						WorkflowTaskCompletedEventId: 13,
+						WorkflowTaskCompletedEventId: 11,
 						RetryPolicy: &common.RetryPolicy{
 							InitialInterval:    durationpb.New(time.Second),
 							BackoffCoefficient: 2,
@@ -350,13 +316,13 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   15,
+				EventId:   13,
 				EventTime: parseTime("2024-05-28T10:04:11.670613Z"),
 				EventType: enums.EVENT_TYPE_ACTIVITY_TASK_STARTED,
 				TaskId:    1048646,
 				Attributes: &history.HistoryEvent_ActivityTaskStartedEventAttributes{
 					ActivityTaskStartedEventAttributes: &history.ActivityTaskStartedEventAttributes{
-						ScheduledEventId: 14,
+						ScheduledEventId: 12,
 						Identity:         "hidden",
 						RequestId:        "bee10f15-2991-47f5-82c4-2be605848abd",
 						Attempt:          1,
@@ -364,7 +330,7 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   16,
+				EventId:   14,
 				EventTime: parseTime("2024-05-28T10:04:12.679629Z"),
 				EventType: enums.EVENT_TYPE_ACTIVITY_TASK_FAILED,
 				TaskId:    1048647,
@@ -386,15 +352,15 @@ func GenCaseFailureHistory(
 								},
 							},
 						},
-						ScheduledEventId: 14,
-						StartedEventId:   15,
+						ScheduledEventId: 12,
+						StartedEventId:   13,
 						Identity:         "hidden",
 						RetryState:       enums.RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED,
 					},
 				},
 			},
 			{
-				EventId:   17,
+				EventId:   15,
 				EventTime: parseTime("2024-05-28T10:04:12.679638Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
 				TaskId:    1048648,
@@ -411,13 +377,13 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   18,
+				EventId:   16,
 				EventTime: parseTime("2024-05-28T10:04:12.692857Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_STARTED,
 				TaskId:    1048652,
 				Attributes: &history.HistoryEvent_WorkflowTaskStartedEventAttributes{
 					WorkflowTaskStartedEventAttributes: &history.WorkflowTaskStartedEventAttributes{
-						ScheduledEventId: 17,
+						ScheduledEventId: 15,
 						Identity:         "hidden",
 						RequestId:        "4e6645eb-08bd-4379-99f3-db2e15fff8d4",
 						HistorySizeBytes: 2153,
@@ -425,14 +391,14 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   19,
+				EventId:   17,
 				EventTime: parseTime("2024-05-28T10:04:12.698410Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
 				TaskId:    1048656,
 				Attributes: &history.HistoryEvent_WorkflowTaskCompletedEventAttributes{
 					WorkflowTaskCompletedEventAttributes: &history.WorkflowTaskCompletedEventAttributes{
-						ScheduledEventId: 17,
-						StartedEventId:   18,
+						ScheduledEventId: 15,
+						StartedEventId:   16,
 						Identity:         "hidden",
 						WorkerVersion: &common.WorkerVersionStamp{
 							BuildId: "81194cb0e5cc14ffb23da13a22ce4152",
@@ -443,7 +409,7 @@ func GenCaseFailureHistory(
 				},
 			},
 			{
-				EventId:   20,
+				EventId:   18,
 				EventTime: parseTime("2024-05-28T10:04:12.698499Z"),
 				EventType: enums.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED,
 				TaskId:    1048657,
@@ -457,7 +423,7 @@ func GenCaseFailureHistory(
 							},
 						},
 						RetryState:                   enums.RETRY_STATE_RETRY_POLICY_NOT_SET,
-						WorkflowTaskCompletedEventId: 19,
+						WorkflowTaskCompletedEventId: 17,
 					},
 				},
 			},

--- a/internal/fake/workflow_run.go
+++ b/internal/fake/workflow_run.go
@@ -2,10 +2,6 @@ package fake
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"go.temporal.io/sdk/client"
@@ -14,102 +10,34 @@ import (
 var _ client.WorkflowRun = (*WorkflowRun)(nil)
 
 type WorkflowRun struct {
-	mu            sync.RWMutex
-	id            string
-	runID         string
-	startSignalCh chan struct{}
-	finished      bool
-	result        any
-	err           error
-	getterChs     []chan any
-	stopCh        chan struct{}
-	isStopped     bool
+	id     string
+	runID  string
+	result any
+	err    error
 }
 
-func StartWorkflowRun(ctx context.Context, timeout time.Duration, id string) *WorkflowRun {
-	wr := &WorkflowRun{
-		id:            id,
-		runID:         uuid.NewString(),
-		startSignalCh: make(chan struct{}, 1),
-		getterChs:     []chan any{},
-		stopCh:        make(chan struct{}),
-		isStopped:     false,
+func newWorkflowRun(id string, result any, err error) *WorkflowRun {
+	return &WorkflowRun{
+		id:     id,
+		runID:  uuid.NewString(),
+		result: result,
+		err:    err,
 	}
-	go func() {
-		ticker := time.NewTicker(timeout)
-		defer ticker.Stop()
-		select {
-		case <-wr.stopCh:
-			wr.mu.Lock()
-			wr.err = errors.New("fake workflow run stopped")
-			return
-		case <-ctx.Done():
-			wr.err = fmt.Errorf("fake workflow run timeout: start workflow signal not received: %w", ctx.Err())
-		case <-ticker.C:
-			wr.err = fmt.Errorf("fake workflow run timeout: start workflow signal not received before timeout %s", timeout)
-		case <-wr.startSignalCh:
-		}
-		wr.mu.Lock()
-		wr.finished = true
-		for _, getter := range wr.getterChs {
-			close(getter)
-		}
-		wr.getterChs = []chan any{}
-		wr.mu.Unlock()
-	}()
-	return wr
 }
 
 func (f *WorkflowRun) GetID() string {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
 	return f.id
 }
 
 func (f *WorkflowRun) GetRunID() string {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
 	return f.runID
 }
 
-func (f *WorkflowRun) Get(ctx context.Context, valuePtr any) error {
-	f.mu.RLock()
-	if f.err != nil {
-		return f.err
-	}
-
-	if f.finished {
-		valuePtr = f.result
-		f.mu.RUnlock()
-		return nil
-	}
-
-	getCh := make(chan any, 1)
-	f.getterChs = append(f.getterChs, getCh)
-	f.mu.RUnlock()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case valuePtr = <-getCh:
-	}
-
-	return nil
+func (f *WorkflowRun) Get(_ context.Context, valuePtr any) error {
+	valuePtr = f.result
+	return f.err
 }
 
 func (f *WorkflowRun) GetWithOptions(ctx context.Context, valuePtr any, _ client.WorkflowRunGetOptions) error {
 	return f.Get(ctx, valuePtr)
-}
-
-func (f *WorkflowRun) signalStart() {
-	close(f.startSignalCh)
-}
-
-func (f *WorkflowRun) stop() {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if !f.isStopped {
-		close(f.stopCh)
-		f.isStopped = true
-	}
 }

--- a/testservice/service.go
+++ b/testservice/service.go
@@ -8,9 +8,8 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 
-	"github.com/annexhq/annex/test"
-
 	"github.com/annexhq/annex/log"
+	"github.com/annexhq/annex/test"
 )
 
 const defaultPageSize int32 = 200
@@ -20,7 +19,6 @@ var _ testservicev1.TestServiceServer = (*Service)(nil)
 type Workflower interface {
 	ExecuteWorkflow(ctx context.Context, options client.StartWorkflowOptions, workflow interface{}, args ...interface{}) (client.WorkflowRun, error)
 	GetWorkflow(ctx context.Context, workflowID string, runID string) client.WorkflowRun
-	SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error
 	GetWorkflowHistory(ctx context.Context, workflowID string, runID string, isLongPoll bool, filterType enums.HistoryEventFilterType) client.HistoryEventIterator
 	ResetWorkflowExecution(ctx context.Context, request *workflowservice.ResetWorkflowExecutionRequest) (*workflowservice.ResetWorkflowExecutionResponse, error)
 	CancelWorkflow(ctx context.Context, workflowID string, runID string) error

--- a/testservice/util_test.go
+++ b/testservice/util_test.go
@@ -20,7 +20,6 @@ type fakeDeps struct {
 func newService() (*Service, *fakeDeps) {
 	repo := inmem.NewTestRepository(inmem.NewDB())
 	workflower := fake.NewWorkflower()
-	defer workflower.Cleanup()
 	return New(repo, workflower), &fakeDeps{
 		repo:       repo,
 		workflower: workflower,


### PR DESCRIPTION
### Background

Test execution start time is not being populated in the Workflow Proxy service `PollWorkflowTaskQueue` method. This was caused by making incorrect assumptions about the first events generated by a new execution along with not even considering that reset workflows have different history events that require specific handling.

### Changes

- Fix Workflow Proxy service `PollWorkflowTaskQueue` method to correctly set test execution start time based on workflow history events.
- Remove start execution workflow signal as it is no longer required due to run id no longer being included in the test execution model.