### PR TITLE
Rename workflow package to workflowservice

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,7 @@ import (
 
 	eventservicev1 "github.com/annexhq/annex-proto/gen/go/rpc/eventservice/v1"
 	testservicev1 "github.com/annexhq/annex-proto/gen/go/rpc/testservice/v1"
-	"go.temporal.io/api/workflowservice/v1"
+	workflowservicev1 "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -19,7 +19,7 @@ import (
 	"github.com/annexhq/annex/internal/health"
 	"github.com/annexhq/annex/log"
 	"github.com/annexhq/annex/testservice"
-	"github.com/annexhq/annex/workflow"
+	"github.com/annexhq/annex/workflowservice"
 )
 
 type Option func(opts *serverOptions)
@@ -93,7 +93,7 @@ func Start(ctx context.Context, cfg Config, opts ...Option) error {
 	grpchealthv1.RegisterHealthServer(srv, healthSvc)
 	testservicev1.RegisterTestServiceServer(srv, testservice.New(deps.repo, tc, testservice.WithLogger(logger)))
 	eventservicev1.RegisterEventServiceServer(srv, event.NewService(deps.eventSrc, deps.repo))
-	workflowservice.RegisterWorkflowServiceServer(srv, workflow.NewProxyService(testClient, tc.WorkflowService()))
+	workflowservicev1.RegisterWorkflowServiceServer(srv, workflowservice.NewProxyService(testClient, tc.WorkflowService()))
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
 	if err != nil {

--- a/workflowservice/custom.go
+++ b/workflowservice/custom.go
@@ -1,4 +1,4 @@
-package workflow
+package workflowservice
 
 import (
 	"context"

--- a/workflowservice/passthrough.go
+++ b/workflowservice/passthrough.go
@@ -1,4 +1,4 @@
-package workflow
+package workflowservice
 
 import (
 	"context"

--- a/workflowservice/service.go
+++ b/workflowservice/service.go
@@ -1,4 +1,4 @@
-package workflow
+package workflowservice
 
 import (
 	testservicev1 "github.com/annexhq/annex-proto/gen/go/rpc/testservice/v1"


### PR DESCRIPTION
Convention used in this repo is to have a 'service' suffix on service packages e.g. `testservice`.

The `workflow` package currently does not follow this convention, so it is being renamed to `workflowservice`.